### PR TITLE
Porting Yocto 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | Other Notes:      | Linumiz, would like to port Yocto on CM3 + Lemuria.   |
 |	            | Its technically feasible to port yocto to rockchip/rk3566, if schematics for CM3 are made available. |
 |		    | Project will be open sourced in post development and early piloting phase, currently it's not public. |
-|		    | Details and photos can be found here <link-to-Linumiz-Lemuria-webpage>. |
+|		    | Details and photos can be found here link-to-Linumiz-Lemuria-webpage |
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,14 @@
-## Apply for Radxa CM3
-
-Radxa is donating some free [ROCK3 computing modules](https://wiki.radxa.com/Rock3/CM3) to open source hardware projects.
-
-
-
-## How to apply
-
-Send a new PR to this repository on GitHub, append your application table. Radxa team will review/ask questions/discuss about the project detail. If the project is interesting or welcomed by the community, we will approve it. Radxa Team will contact the developer for the further sample shipping&development etc.
-
-
-
 ## CM3 projects list:
 
-| Project Name:     | TBD     |
-| ----------------- | ---- |
-| CM3 Model:        | WiFi, eMMC, 4GB+ RAM preferred     |
-| Project Hardware: | Currently the RPi CM4 + LCD    |
+| Project Name:     | Lemuria  |
+| ----------------- | -------- |
+| CM3 Model:        | WiFi, eMMC,  RAM >= 4GB    |
+| Project Hardware: | Currently the RPi CM4     |
 | Project Software: | Raspbian/Linux     |
-| Other Notes:      | Project will be open sourced closer to going on sale, currently it's not public, details and photos can be shared privately. There is some tease photos here: https://twitter.com/arturo182/status/1364003299083624452     |
+| Other Notes:      | Linumiz, would like to port Yocto on CM3 + Lemuria.   |
+|	            | Its technically feasible to port yocto to rockchip/rk3566, if schematics for CM3 are made available. |
+|		    | Project will be open sourced in post development and early piloting phase, currently it's not public. |
+|		    | Details and photos can be found here <link-to-Linumiz-Lemuria-webpage>. |
 
 
-| Project Name:     | currypi                               |
-| ----------------- | ----                                  |
-| CM3 Model:        | RM116-D8E\*                           |
-| Project Hardware: | https://github.com/devguardio/currypi |
-| Project Software: | |
-| Other Notes:      | pictures: https://twitter.com/arvidep/status/1445363759313297412 |
-
-| Project Name:     | NixOS |
-| ----------------- | ----- |
-| CM3 Model:        | eMMC (>= 32 GB), WiFi (optional)|
-| Project Hardware: | Radxa E23 Dual Ethernet Board |
-| Project Software: | NixOS |
-| Other Notes:      | - |
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
+## Apply for Radxa CM3
+
+Radxa is donating some free [ROCK3 computing modules](https://wiki.radxa.com/Rock3/CM3) to open source hardware projects.
+
+
+
+## How to apply
+
+Send a new PR to this repository on GitHub, append your application table. Radxa team will review/ask questions/discuss about the project detail. If the project is interesting or welcomed by the community, we will approve it. Radxa Team will contact the developer for the further sample shipping&development etc.
+
+
+
 ## CM3 projects list:
+
+| Project Name:     | TBD     |
+| ----------------- | ---- |
+| CM3 Model:        | WiFi, eMMC, 4GB+ RAM preferred     |
+| Project Hardware: | Currently the RPi CM4 + LCD    |
+| Project Software: | Raspbian/Linux     |
+| Other Notes:      | Project will be open sourced closer to going on sale, currently it's not public, details and photos can be shared privately. There is some tease photos here: https://twitter.com/arturo182/status/1364003299083624452     |
+
+
+| Project Name:     | currypi                               |
+| ----------------- | ----                                  |
+| CM3 Model:        | RM116-D8E\*                           |
+| Project Hardware: | https://github.com/devguardio/currypi |
+| Project Software: | |
+| Other Notes:      | pictures: https://twitter.com/arvidep/status/1445363759313297412 |
+
+| Project Name:     | NixOS |
+| ----------------- | ----- |
+| CM3 Model:        | eMMC (>= 32 GB), WiFi (optional)|
+| Project Hardware: | Radxa E23 Dual Ethernet Board |
+| Project Software: | NixOS |
+| Other Notes:      | - |
 
 | Project Name:     | Lemuria  |
 | ----------------- | -------- |
@@ -6,6 +40,7 @@
 | Project Hardware: | Currently the RPi CM4     |
 | Project Software: | Raspbian/Linux     |
 | Other Notes:      | Linumiz, would like to port Yocto on CM3 + Lemuria.   |
+|		    | Lemuria is a low cost IIOT Gateway to address various industrial needs with rich set of interfaces |
 |	            | Its technically feasible to port yocto to rockchip/rk3566, if schematics for CM3 are made available. |
 |		    | Project will be open sourced in post development and early piloting phase, currently it's not public. |
 |		    | Details and photos can be found here link-to-Linumiz-Lemuria-webpage |


### PR DESCRIPTION
Linumiz would like to port Yocto on CM3 + Lemuria.
Its technically feasible to port Yocto to rockchip/rk3566, if schematics for CM3 are made available.
We abide by to open source model. We contribute to community-driven open source projects.
We will be committed to developing the meta-radxa-cm3 layer on Yocto and mainline the same for community benefit.